### PR TITLE
Switch to pytest for test running (#240)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ python:
     - "pypy3.5"
     - "pypy3"
 install:
-    - pip install -r requirements-dev.txt
+    - pip install --upgrade -r requirements-dev.txt
     # mypy can't be installed on pypy
     - if [[ "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then pip install mypy ; fi
     - if [[ "${TRAVIS_PYTHON_VERSION}" != *"3.5"* && "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then
         pip install black ; fi
 script:
     # no IPv6 support in Travis :(
-    - make TEST_ARGS='-a "!IPv6"' ci
+    - SKIP_IPV6=1 make ci
 after_success:
     - coveralls

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 MAX_LINE_LENGTH=110
 PYTHON_IMPLEMENTATION:=$(shell python -c "import sys;import platform;sys.stdout.write(platform.python_implementation())")
 PYTHON_VERSION:=$(shell python -c "import sys;sys.stdout.write('%d.%d' % sys.version_info[:2])")
-TEST_ARGS=
 
 LINT_TARGETS:=flake8
 
@@ -40,10 +39,10 @@ mypy:
 	mypy examples/*.py zeroconf/*.py
 
 test:
-	nosetests -v $(TEST_ARGS)
+	pytest -v zeroconf/test.py
 
 test_coverage:
-	nosetests -v --with-coverage --cover-package=zeroconf $(TEST_ARGS)
+	pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing zeroconf/test.py
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ coverage
 flake8>=3.6.0
 flake8-import-order
 ifaddr
-nose
 pep8-naming!=0.6.0
+pytest
+pytest-cov


### PR DESCRIPTION
Nose is dead for all intents and purposes (last release in 2015) and
pytest provide a very valuable feature of printing relevant extra
information in case of assertion failure (from[1]):

    ================================= FAILURES =================================
    _______________________________ test_answer ________________________________

        def test_answer():
    >       assert func(3) == 5
    E       assert 4 == 5
    E        +  where 4 = func(3)

    test_sample.py:6: AssertionError
    ========================= short test summary info ==========================
    FAILED test_sample.py::test_answer - assert 4 == 5
    ============================ 1 failed in 0.12s =============================

This should be helpful in debugging tests intermittently failing on
PyPy.

Several TestCase.assertEqual() calls have been replaced by plain
assertions now that that method no longer provides anything we can't get
without it. Few assertions have been modified to not explicitly provide
extra information in case of failure – pytest will provide this
automatically.

Dev dependencies are forced to be the latest versions to make sure
we don't fail because of outdated ones on Travis.

[1] https://docs.pytest.org/en/latest/getting-started.html#create-your-first-test